### PR TITLE
Use ContentMargins to shrink the ScrollView, instead of a Spacer 

### DIFF
--- a/KeyboardAttachedView/ContentView.swift
+++ b/KeyboardAttachedView/ContentView.swift
@@ -24,9 +24,8 @@ struct ContentView: View {
 						Spacer()
 					}
 				}
-				Spacer()
-					.frame(height: min(max(-offset, 0), .infinity))
 			}
+            .contentMargins(.bottom, -offset)
 			.scrollDismissesKeyboard(.interactively)
 			.scrollClipDisabled()
 			.defaultScrollAnchor(.bottom)

--- a/KeyboardAttachedView/ContentView.swift
+++ b/KeyboardAttachedView/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
 					}
 				}
 			}
-            .contentMargins(.bottom, -offset)
+			.contentMargins(.bottom, -offset)
 			.scrollDismissesKeyboard(.interactively)
 			.scrollClipDisabled()
 			.defaultScrollAnchor(.bottom)


### PR DESCRIPTION
This means that the Scroll Indicator works properly, and also seems to perform slightly better.
